### PR TITLE
Mark/autodrive sim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 ## Windows Setup for AutoDRIVE F1Tenth Simulator
 
-#### Repo Setup
+#### Development Space Setup
 1. Download Ubuntu in Microsoft Store (The one without any extension)
 2. Install Docker Destop: Settings -> Resources -> WSL Integration -> Enable Ubuntu
 3. Go into Ubuntu and setup username and password, if first time installing
-4. In the your home directory (~), run: `git clone https://github.com/WATonomous/wato_f1tenth.git`
-5. Go into the repo by running: cd wato_f1tenth
-6. Attach vscode to this repo by running (Asssuming you have vscode): code . 
-7. Run ./watod up to build and up the container
+4. In your home directory (~), run: `git clone https://github.com/WATonomous/wato_f1tenth.git`
+5. Go into the repo: `cd wato_f1tenth`
+6. Start VSCode: `code .`
+7. Make sure the `watod-config.sh` file has: `ACTIVE_MODULES="vis_tools robot sim"` and `MODE_OF_OPERATION="develop"`. 
+8. Run `./watod build && ./watod up` to start the containers. Future starts can just be `./watod up` if you don't need to rebuild containers.
+9. Download the Docker extension for VSCode. 
+10. From the extension pannel, right click on the `-robot_dev-1` container and attach a VSCode.
+11. In the opened VSCode window select the `/home/bolty/ament_ws` folder. This will be where you do your development!
 
 #### Connecting the AutoDRIVE Simulator
-8. Download the `practice` simulator from: https://autodrive-ecosystem.github.io/competitions/f1tenth-sim-racing-iros-2024/#resources
-9. Unzip the download and run `AutoDRIVE Simulator.exe` inside the folder
-10. Open the left menu on the simulator application
-11. Press on the button "Disconnected" to attempt connection to your running watod containers. The default port should already be 4567.
-12. You should see "Connected"- this means your physics simulator is connected to your watod containers and everything is setup correct!
+1. Download the `practice` simulator from: https://autodrive-ecosystem.github.io/competitions/f1tenth-sim-racing-iros-2024/#resources
+2. Unzip the download and run `AutoDRIVE Simulator.exe` inside the folder
+3. Open the left menu on the simulator application
+4. Press on the button "Disconnected" to attempt connection to your running watod containers. The default port should already be 4567.
+5. You should see "Connected"- this means your physics simulator is connected to your watod containers and everything is setup correctly!
+6. There is built-in Keyboard Teleop in the simulator. Click on "Autonomous" to set driving mode to "Manual", you will be able to drive with WASD.
+
+#### Note for other OS (Ubuntu and MacOS)
+This guide was only written & tested on Windows. 
+- Try the above steps and if you have any problems, ping an F1Tenth Lead on the Discord channel!

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # WATonomous F1Tenth
 
-## Initial Windows Setup for visualizing in Foxglove
+## Windows Setup for AutoDRIVE F1Tenth Simulator
+
+#### Repo Setup
 1. Download Ubuntu in Microsoft Store (The one without any extension)
 2. Install Docker Destop: Settings -> Resources -> WSL Integration -> Enable Ubuntu
 3. Go into Ubuntu and setup username and password, if first time installing
-4. In the your home directory (~), run: git clone https://github.com/WATonomous/wato_f1tenth.git
+4. In the your home directory (~), run: `git clone https://github.com/WATonomous/wato_f1tenth.git`
 5. Go into the repo by running: cd wato_f1tenth
 6. Attach vscode to this repo by running (Asssuming you have vscode): code . 
-7. In VS Code, manually forward the port by going to PORTS -> Add Port -> Enter 2000 for port number
-8. Run ./watod up to build and up the container
-9. Go to foxglove: Open Connection -> Foxglove Websocket -> Enter ws://localhost:20000
-10. Now go to the Panel section on the left -> click the 3D Panel in the middle -> Topics -> Hover your cursor on the map and click the eye button to make map visible
+7. Run ./watod up to build and up the container
 
-Now you should be able to see the car with transforms and the map
+#### Connecting the AutoDRIVE Simulator
+8. Download the `practice` simulator from: https://autodrive-ecosystem.github.io/competitions/f1tenth-sim-racing-iros-2024/#resources
+9. Unzip the download and run `AutoDRIVE Simulator.exe` inside the folder
+10. Open the left menu on the simulator application
+11. Press on the button "Disconnected" to attempt connection to your running watod containers. The default port should already be 4567.
+12. You should see "Connected"- this means your physics simulator is connected to your watod containers and everything is setup correct!

--- a/docker/robot/robot.Dockerfile
+++ b/docker/robot/robot.Dockerfile
@@ -31,6 +31,7 @@ RUN sudo apt-get clean && \
     sudo rosdep update
 
 # ADD MORE DEPENDENCIES HERE
+RUN sudo apt-get install libeigen3-dev
 
 # Install Rosdep requirements
 COPY --from=source /tmp/colcon_install_list /tmp/colcon_install_list

--- a/docker/sim/sim_autodrive.Dockerfile
+++ b/docker/sim/sim_autodrive.Dockerfile
@@ -1,0 +1,29 @@
+# MIT License
+
+# Copyright (c) 2020 Hongrui Zheng
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM autodriveecosystem/autodrive_f1tenth_api:2024-cdc-practice
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /home/autodrive_devkit
+COPY docker/sim/sim_autodrive_entrypoint.sh /home/autodrive_devkit/sim_autodrive_entrypoint.sh
+ENTRYPOINT ["./sim_autodrive_entrypoint.sh"]

--- a/docker/sim/sim_autodrive_entrypoint.sh
+++ b/docker/sim/sim_autodrive_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Launch API node
+source /opt/ros/humble/setup.bash
+source install/setup.bash
+
+ls
+ros2 launch autodrive_f1tenth simulator_bringup_headless.launch.py

--- a/docker/sim/sim_autodrive_entrypoint.sh
+++ b/docker/sim/sim_autodrive_entrypoint.sh
@@ -5,5 +5,6 @@ set -e
 source /opt/ros/humble/setup.bash
 source install/setup.bash
 
-ls
+sed -i '284c\        autodrive.lidar_range_array = np.fromstring(data["V1 LIDAR Range Array"], sep="\\n")' src/autodrive_devkit/autodrive_f1tenth/autodrive_bridge.py
+colcon build
 ros2 launch autodrive_f1tenth simulator_bringup_headless.launch.py

--- a/modules/docker-compose.sim.yaml
+++ b/modules/docker-compose.sim.yaml
@@ -12,6 +12,10 @@ services:
     image: autodrive_f1tenth:latest
     ports:
       - "4567:4567"
+      - "7400:7400/udp"
+      - "7401:7401/udp"
+      - "7410:7410/udp"
+      - "7411:7411/udp"
     profiles: [deploy, develop]
     # command: /bin/sh -c "echosus" #"ros2 launch autodrive_f1tenth simulator_bringup_headless.launch.py"
     # tty: true

--- a/modules/docker-compose.sim.yaml
+++ b/modules/docker-compose.sim.yaml
@@ -2,17 +2,17 @@ services:
   sim:
     build:
       context: ..
-      dockerfile: docker/sim/sim.Dockerfile
+      dockerfile: docker/sim/sim_autodrive.Dockerfile
       # cache_from:
       #   - "${GAZEBO_SERVER_IMAGE:?}:${TAG}"
       #   - "${GAZEBO_SERVER_IMAGE:?}:main"
       # args:
       #   BASE_IMAGE: ${BASE_IMAGE_OVERRIDE-}
     # image: "${GAZEBO_SERVER_IMAGE:?}:${TAG}"
-    image: f1tenth:latest
-    # ports:
-    #   - "${GAZEBO_PORT:?}:9002"
+    image: autodrive_f1tenth:latest
+    ports:
+      - "4567:4567"
     profiles: [deploy, develop]
-    command: /bin/bash -c "ros2 launch f1tenth_gym_ros gym_bridge_launch.py"
+    # command: /bin/sh -c "echosus" #"ros2 launch autodrive_f1tenth simulator_bringup_headless.launch.py"
     # tty: true
     # command: /bin/bash


### PR DESCRIPTION
AutoDRIVE Sim Integration PR
- Replaces the old f1tenth-gym-ros simulator with a fancy, more realistic (& competition required :)) simulation
- Updated README.md for the installation steps

Documentation on simulator rostopics & more: https://autodrive-ecosystem.github.io/competitions/f1tenth-sim-racing-guide/